### PR TITLE
docs: improve dumi announcement cover

### DIFF
--- a/db.json
+++ b/db.json
@@ -10,8 +10,8 @@
       },
       {
         "title": "dumi 1.1 发布，你更好用的组件研发利器！",
-        "description": "沉淀 304 天，全新的 dumi 1.1 版本，在 2021 年前夕和大家分享",
-        "img": "https://gw.alipayobjects.com/zos/bmw-prod/8f6a2bdb-64bc-4a84-9d59-bc8aa030f2ca/kjcodlvy_w980_h384.png",
+        "description": "沉淀 304 天，全新的 dumi 1.1 版本，在 2021 年伊始和大家分享",
+        "img": "https://gw.alipayobjects.com/zos/bmw-prod/6bdb352f-0c35-4b67-98ac-e3850ddfefaa/kjek8keu_w980_h384.png",
         "href": "https://zhuanlan.zhihu.com/p/340845825"
       },
       {
@@ -32,7 +32,7 @@
       {
         "title": "Announcing dumi 1.1, a better component development tool for you!",
         "description": "What we want to share with you on the eve of 2021 is the v1.1.0 of brand new dumi",
-        "img": "https://gw.alipayobjects.com/zos/bmw-prod/8f6a2bdb-64bc-4a84-9d59-bc8aa030f2ca/kjcodlvy_w980_h384.png",
+        "img": "https://gw.alipayobjects.com/zos/bmw-prod/def29ea9-f55a-42d8-9b26-b564387357d3/kjeka42u_w980_h384.png",
         "href": "https://zhuanlan.zhihu.com/p/340845825"
       },
       {


### PR DESCRIPTION
## 修改内容

上个版本未经充分验证，导致封面图和标题干扰了，影响首页呈现效果：
<img width="489" alt="图片" src="https://user-images.githubusercontent.com/5035925/103443579-9fd35080-4c9b-11eb-8aff-35677428d07e.png">
<img width="489" alt="图片" src="https://user-images.githubusercontent.com/5035925/103443582-abbf1280-4c9b-11eb-9295-01a2022f3b88.png">

PR 的版本效果：
<img width="493" alt="图片" src="https://user-images.githubusercontent.com/5035925/103443592-d7da9380-4c9b-11eb-8fd2-c9d45e38301f.png">
<img width="487" alt="图片" src="https://user-images.githubusercontent.com/5035925/103443600-e923a000-4c9b-11eb-82ed-530363507195.png">
